### PR TITLE
security: bump MessagePack 2.5.140 -> 2.5.187 (CVE-2024-48924)

### DIFF
--- a/backend/RelationshipManager.Api/RelationshipManager.Api.csproj
+++ b/backend/RelationshipManager.Api/RelationshipManager.Api.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.1.2" />
-    <PackageReference Include="MessagePack" Version="2.5.140" />
+    <PackageReference Include="MessagePack" Version="2.5.187" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes CVE-2024-48924. `backend/RelationshipManager.Api` builds successfully.